### PR TITLE
Rename some response objects to match the swagger documentation

### DIFF
--- a/ResidentContactApi.Tests/E2ETestsHelper.cs
+++ b/ResidentContactApi.Tests/E2ETestsHelper.cs
@@ -37,17 +37,17 @@ namespace ResidentContactApi.Tests
                 LastName = resident.LastName,
                 Gender = "F",
                 DateOfBirth = resident.DateOfBirth,
-                Contacts =
+                ContactInformation =
                     new List<ContactDetailsResponse>
                     {
                         new ContactDetailsResponse
                         {
 
                             Id = contact.Id,
-                            ContactValue = contact.ContactValue,
+                            Value = contact.ContactValue,
                             AddedBy = contact.AddedBy,
-                            IsActive = contact.IsActive,
-                            IsDefault = contact.IsDefault,
+                            Active = contact.IsActive,
+                            Default = contact.IsDefault,
                             DateLastModified = contact.DateLastModified,
                             ModifiedBy = contact.ModifiedBy,
                             DateAdded = contact.DateAdded,

--- a/ResidentContactApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/ResidentContactApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -33,7 +33,7 @@ namespace ResidentContactApi.Tests.V1.Factories
                 LastName = "Last",
                 DateOfBirth = new DateTime(),
                 Gender = "F",
-                Contacts = null
+                ContactInformation = null
             };
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
         }
@@ -65,7 +65,7 @@ namespace ResidentContactApi.Tests.V1.Factories
                 LastName = "Last",
                 DateOfBirth = new DateTime(),
                 Gender = "F",
-                Contacts = new List<ContactDetailsResponse>
+                ContactInformation = new List<ContactDetailsResponse>
                 {
                     new ContactDetailsResponse
                     {
@@ -100,10 +100,10 @@ namespace ResidentContactApi.Tests.V1.Factories
             {
                 Id = 1234,
                 Type = "Address",
-                ContactValue = "123456",
+                Value = "123456",
                 AddedBy = "test",
-                IsActive = false,
-                IsDefault = false,
+                Active = false,
+                Default = false,
                 DateLastModified = new DateTime(2020, 04, 23),
                 ModifiedBy = "Tester",
                 SubType = "Home",

--- a/ResidentContactApi.Tests/V1/UseCase/GetByIdUseCaseTests.cs
+++ b/ResidentContactApi.Tests/V1/UseCase/GetByIdUseCaseTests.cs
@@ -46,7 +46,7 @@ namespace ResidentContactApi.Tests.V1.UseCase
             var expectedResponse = stubbedResidentInfo.ToResponse();
             var expectedContactResponse = stubbedResidentInfo.Contacts.ToResponse();
 
-            response.Contacts.Should().BeEquivalentTo(expectedContactResponse);
+            response.ContactInformation.Should().BeEquivalentTo(expectedContactResponse);
             response.Should().NotBeNull();
             response.Should().BeEquivalentTo(expectedResponse);
 

--- a/ResidentContactApi/V1/Boundary/Response/ContactDetailsResponse.cs
+++ b/ResidentContactApi/V1/Boundary/Response/ContactDetailsResponse.cs
@@ -10,17 +10,15 @@ namespace ResidentContactApi.V1.Boundary.Response
     public class ContactDetailsResponse
     {
         public int Id { get; set; }
-        public string ContactValue { get; set; }
+        public string Value { get; set; }
         public string Type { get; set; }
         public string SubType { get; set; }
-        public bool IsDefault { get; set; }
-        public bool IsActive { get; set; }
+        public bool Default { get; set; }
+        public bool Active { get; set; }
         public string AddedBy { get; set; }
         public DateTime DateAdded { get; set; }
         public string ModifiedBy { get; set; }
         public DateTime DateLastModified { get; set; }
-
         public int ResidentId { get; set; }
-        public ResidentResponse Resident { get; set; }
     }
 }

--- a/ResidentContactApi/V1/Boundary/Response/ResidentResponse.cs
+++ b/ResidentContactApi/V1/Boundary/Response/ResidentResponse.cs
@@ -10,6 +10,6 @@ namespace ResidentContactApi.V1.Boundary.Response
         public string LastName { get; set; }
         public DateTime? DateOfBirth { get; set; }
         public string Gender { get; set; }
-        public List<ContactDetailsResponse> Contacts { get; set; }
+        public List<ContactDetailsResponse> ContactInformation { get; set; }
     }
 }

--- a/ResidentContactApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentContactApi/V1/Factories/ResponseFactory.cs
@@ -17,7 +17,7 @@ namespace ResidentContactApi.V1.Factories
                 FirstName = domain.FirstName,
                 LastName = domain.LastName,
                 DateOfBirth = domain.DateOfBirth,
-                Contacts = domain.Contacts?.Select(x => x.ToResponse()).ToList(),
+                ContactInformation = domain.Contacts?.Select(x => x.ToResponse()).ToList(),
                 Gender = domain.Gender.ToString(),
             };
         }
@@ -32,10 +32,10 @@ namespace ResidentContactApi.V1.Factories
             {
                 Id = contactDetails.Id,
                 Type = contactDetails.Type,
-                ContactValue = contactDetails.ContactValue,
+                Value = contactDetails.ContactValue,
                 AddedBy = contactDetails.AddedBy,
-                IsActive = contactDetails.IsActive,
-                IsDefault = contactDetails.IsDefault,
+                Active = contactDetails.IsActive,
+                Default = contactDetails.IsDefault,
                 DateLastModified = contactDetails.DateLastModified,
                 ModifiedBy = contactDetails.ModifiedBy,
                 SubType = contactDetails.SubType,

--- a/ResidentContactApi/V1/Gateways/ResidentGateway.cs
+++ b/ResidentContactApi/V1/Gateways/ResidentGateway.cs
@@ -1,15 +1,10 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Internal;
 using ResidentContactApi.V1.Boundary.Requests;
 using ResidentContactApi.V1.Domain;
 using ResidentContactApi.V1.Factories;
 using ResidentContactApi.V1.Infrastructure;
-using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
-using System.Net.NetworkInformation;
-using System.Threading.Tasks;
 
 namespace ResidentContactApi.V1.Gateways
 {


### PR DESCRIPTION
A few field names were slightly different to the swagger documentation, so have updated the response objects.