### PR TITLE
Can create contact details from resident ID or contact details ID

### DIFF
--- a/ResidentContactApi.Tests/E2ETestsHelper.cs
+++ b/ResidentContactApi.Tests/E2ETestsHelper.cs
@@ -53,13 +53,30 @@ namespace ResidentContactApi.Tests
                             DateAdded = contact.DateAdded,
                             Type = contactType.Name,
                             SubType = subContactType.Name
-
                         }
                     }
-
-
             };
+        }
 
+        public static string AddCrmContactIdForResidentId(ResidentContactContext context, int residentId)
+        {
+            var fixture = new Fixture();
+            var externalSystemLookup = new ExternalSystemLookup
+            {
+                Name = "CRM"
+            };
+            context.ExternalSystemLookups.Add(externalSystemLookup);
+            context.SaveChanges();
+            var externalLink = new ExternalSystemId
+            {
+                ResidentId = residentId,
+                ExternalIdName = "ContactId",
+                ExternalSystemLookupId = externalSystemLookup.Id,
+                ExternalIdValue = fixture.Create<string>()
+            };
+            context.ExternalSystemIds.Add(externalLink);
+            context.SaveChanges();
+            return externalLink.ExternalIdValue;
         }
     }
 }

--- a/ResidentContactApi.Tests/V1/Controllers/ResidentContactApiControllerTest.cs
+++ b/ResidentContactApi.Tests/V1/Controllers/ResidentContactApiControllerTest.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ResidentContactApi.V1.Boundary;
 using ResidentContactApi.V1.Boundary.Response;
 
 namespace ResidentContactApi.Tests.V1.Controllers
@@ -105,16 +106,35 @@ namespace ResidentContactApi.Tests.V1.Controllers
         }
 
         [Test]
-        public void CreateRecordTest()
+        public void CreateRecordReturns201IfSuccessful()
         {
-            var response = new ResidentResponse();
-            _mockCreateContactDetails.Setup(x => x.Execute(It.IsAny<ResidentContact>())).Returns(response);
+            var useCaseResponse = new ContactDetailsResponse();
+            _mockCreateContactDetails.Setup(x => x.Execute(It.IsAny<ResidentContact>())).Returns(useCaseResponse);
             var result = _classUnderTest.CreateContactRecord(It.IsAny<ResidentContact>()) as CreatedAtActionResult;
 
-            response.Should().NotBeNull();
-            result.Value.Should().BeOfType<ResidentResponse>();
+            result.Should().NotBeNull();
+            result.Value.Should().BeEquivalentTo(useCaseResponse);
             result.StatusCode.Should().Be(201);
         }
-    }
 
+        [Test]
+        public void CreateRecordReturns400IfNoIdExceptionThrown()
+        {
+            _mockCreateContactDetails.Setup(x => x.Execute(It.IsAny<ResidentContact>())).Throws<NoIdentifierException>();
+            var result = _classUnderTest.CreateContactRecord(It.IsAny<ResidentContact>()) as BadRequestObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public void CreateRecordReturns400IfResidentNotFoundExceptionThrown()
+        {
+            _mockCreateContactDetails.Setup(x => x.Execute(It.IsAny<ResidentContact>())).Throws<ResidentNotFoundException>();
+            var result = _classUnderTest.CreateContactRecord(It.IsAny<ResidentContact>()) as BadRequestObjectResult;
+
+            result.Should().NotBeNull();
+            result.StatusCode.Should().Be(400);
+        }
+    }
 }

--- a/ResidentContactApi.Tests/V1/E2ETests/CreateContactRecordTests.cs
+++ b/ResidentContactApi.Tests/V1/E2ETests/CreateContactRecordTests.cs
@@ -3,12 +3,14 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using ResidentContactApi.V1.Boundary.Response;
 using ResidentContactApi.V1.Boundary.Requests;
 using Bogus;
 using System.Text;
 using System.Net.Http;
+using ResidentContactApi.V1.Infrastructure;
 
 namespace ResidentContactApi.Tests.V1.E2ETests
 {
@@ -35,11 +37,10 @@ namespace ResidentContactApi.Tests.V1.E2ETests
                 contactSubTypeLookupId: contactRequest.SubtypeId);
 
             contactRequest.ResidentId = resident.Id;
-            var url = new Uri($"/api/v1/contact-details/", UriKind.Relative);
-            using var content = new StringContent(JsonConvert.SerializeObject(contactRequest), Encoding.UTF8, "application/json");
-            using var response = await Client.PostAsync(url, content).ConfigureAwait(true);
+            var response = await CallPostEndpointWithRequest(contactRequest).ConfigureAwait(true);
 
             response.StatusCode.Should().Be(201);
+            CheckContactHasBeSavedInDatabaseForResidentId(resident.Id, contactRequest);
         }
 
 
@@ -51,11 +52,54 @@ namespace ResidentContactApi.Tests.V1.E2ETests
                 Value = null
             };
 
-            var url = new Uri($"/api/v1/contact-details", UriKind.Relative);
-            using var content = new StringContent(JsonConvert.SerializeObject(contactRequest), Encoding.UTF8, "application/json");
-            using var response = await Client.PostAsync(url, content).ConfigureAwait(true);
+            var response = await CallPostEndpointWithRequest(contactRequest).ConfigureAwait(true);
             response.StatusCode.Should().Be(400);
         }
 
+        [Test]
+        public async Task CanCreateANewContactDetailGivenAnExternalContactIdToIdentifyTheResident()
+        {
+            var contactRequest = new ResidentContact
+            {
+                SubtypeId = _faker.Random.Int(1, 50),
+                TypeId = _faker.Random.Int(1, 50),
+                Value = "test@test",
+                Active = _faker.Random.Bool(),
+                Default = _faker.Random.Bool()
+            };
+
+
+            var resident = E2ETestsHelper.AddPersonWithRelatedEntitiesToDb(ResidentContactContext,
+                contactTypeLookupId: contactRequest.TypeId,
+                contactSubTypeLookupId: contactRequest.SubtypeId);
+            contactRequest.NccContactId = E2ETestsHelper.AddCrmContactIdForResidentId(ResidentContactContext, resident.Id);
+
+            var response = await CallPostEndpointWithRequest(contactRequest).ConfigureAwait(true);
+
+            response.StatusCode.Should().Be(201);
+            CheckContactHasBeSavedInDatabaseForResidentId(resident.Id, contactRequest);
+        }
+
+        private void CheckContactHasBeSavedInDatabaseForResidentId(int residentId, ResidentContact contactRequest)
+        {
+            var savedContact = ResidentContactContext.ContactDetails
+                .Where(c => c.ResidentId == residentId)
+                .FirstOrDefault(c => c.ContactValue == contactRequest.Value);
+            savedContact.Should().NotBeNull();
+            savedContact.ContactValue.Should().BeEquivalentTo(contactRequest.Value);
+            savedContact.ContactSubTypeLookupId.Should().Be(contactRequest.SubtypeId);
+            savedContact.ContactTypeLookupId.Should().Be(contactRequest.TypeId);
+            savedContact.IsActive.Should().Be(contactRequest.Active);
+            savedContact.IsDefault.Should().Be(contactRequest.Default);
+        }
+
+        private async Task<HttpResponseMessage> CallPostEndpointWithRequest(ResidentContact contactRequest)
+        {
+            var url = new Uri("/api/v1/contact-details", UriKind.Relative);
+            using var content =
+                new StringContent(JsonConvert.SerializeObject(contactRequest), Encoding.UTF8, "application/json");
+            using var response = await Client.PostAsync(url, content).ConfigureAwait(true);
+            return response;
+        }
     }
 }

--- a/ResidentContactApi/V1/Boundary/NoIdentifierException.cs
+++ b/ResidentContactApi/V1/Boundary/NoIdentifierException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace ResidentContactApi.V1.Boundary
+{
+    public class NoIdentifierException : Exception
+    {
+    }
+}

--- a/ResidentContactApi/V1/Boundary/Requests/ResidentContact.cs
+++ b/ResidentContactApi/V1/Boundary/Requests/ResidentContact.cs
@@ -5,8 +5,9 @@ namespace ResidentContactApi.V1.Boundary.Requests
 {
     public class ResidentContact
     {
-        [Required]
-        public int ResidentId { get; set; }
+        public int? ResidentId { get; set; }
+
+        public string NccContactId { get; set; }
 
         //Value eg. a phone or mobile number, e-mail address etc.
         [Required]

--- a/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
+++ b/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
@@ -6,6 +6,7 @@ using ResidentContactApi.V1.Boundary.Requests;
 using ResidentContactApi.V1.Domain;
 using System.Net.Mail;
 using System;
+using ResidentContactApi.V1.Boundary;
 
 namespace ResidentContactApi.V1.Controllers
 {
@@ -75,13 +76,17 @@ namespace ResidentContactApi.V1.Controllers
             try
             {
                 var resident = _createContactDetails.Execute(rcp);
-                return CreatedAtAction("ViewRecord", new { id = resident.Id }, resident);
+                return CreatedAtAction("ViewRecord", resident);
             }
-            catch (Exception e)
+            catch (NoIdentifierException)
             {
-                return BadRequest(e.Message);
+                return BadRequest(
+                    "Request must include either the residents ID or the contact ID for the resident from NCC");
             }
-
+            catch (ResidentNotFoundException)
+            {
+                return BadRequest("Resident ID and/or NCC Contact ID do not link to a resident record");
+            }
         }
     }
 }

--- a/ResidentContactApi/V1/Domain/ContactDetailsDomain.cs
+++ b/ResidentContactApi/V1/Domain/ContactDetailsDomain.cs
@@ -7,7 +7,9 @@ namespace ResidentContactApi.V1.Domain
         public int Id { get; set; }
         public string ContactValue { get; set; }
         public string Type { get; set; }
+        public int TypeId { get; set; }
         public string SubType { get; set; }
+        public int? SubtypeId { get; set; }
         public bool IsDefault { get; set; }
         public bool IsActive { get; set; }
         public string AddedBy { get; set; }

--- a/ResidentContactApi/V1/Gateways/IResidentGateway.cs
+++ b/ResidentContactApi/V1/Gateways/IResidentGateway.cs
@@ -1,9 +1,6 @@
-using ResidentContactApi.V1.Boundary.Requests;
 using ResidentDomain = ResidentContactApi.V1.Domain.ResidentDomain;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using ResidentContactApi.V1.Domain;
 
 namespace ResidentContactApi.V1.Gateways
 {
@@ -11,7 +8,6 @@ namespace ResidentContactApi.V1.Gateways
     {
         List<ResidentDomain> GetResidents(int limit, int cursor, string firstName, string lastName);
         ResidentDomain GetResidentById(int id);
-        ResidentDomain InsertResidentContactDetails(ResidentContact rcp);
-
+        int? InsertResidentContactDetails(int? residentId, string nccContactId, ContactDetailsDomain contactDetails);
     }
 }

--- a/ResidentContactApi/V1/UseCase/Interfaces/ICreateContactDetailsUseCase.cs
+++ b/ResidentContactApi/V1/UseCase/Interfaces/ICreateContactDetailsUseCase.cs
@@ -5,7 +5,7 @@ namespace ResidentContactApi.V1.UseCase.Interfaces
 {
     public interface ICreateContactDetailsUseCase
     {
-        ResidentResponse Execute(ResidentContact rcp);
+        ContactDetailsResponse Execute(ResidentContact contactRequest);
     }
 }
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-159

## Describe this PR

The NCC API needs to POST to this API when it adds new contact detail. The POST endpoint currently accepts a resident ID in order to add a contact detail however the NCC API doesn't know the Resident ID which is being stored in the database for this API.

### *What changes have we introduced*

This PR changes the POST endpoint to either accept a resident ID of an NCC contact ID for a resident in order to complete the update.

When trying to find a resident, It will in the first case use the resident ID but if that ID is missing or incorrect it will look to use the contact Id if provided.

It also adds some error reporting which was missing so the POST endpoint will now return a 400 response if both ID's are missing or if a resident can't be found by either ID.

Finally, this also changes the response to return the contact details ID from the newly created entity instead of returning the resident ID

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Changes to Swagger Docs