### PR TITLE
Insert resident record endpoint

### DIFF
--- a/ResidentContactApi.Tests/E2ETestsHelper.cs
+++ b/ResidentContactApi.Tests/E2ETestsHelper.cs
@@ -3,11 +3,13 @@ using ResidentContactApi.V1.Boundary.Response;
 using ResidentContactApi.V1.Infrastructure;
 using System.Collections.Generic;
 using AutoFixture;
+using Bogus;
 
 namespace ResidentContactApi.Tests
 {
     public static class E2ETestsHelper
     {
+        private static readonly Faker _faker = new Faker();
         public static ResidentResponse AddPersonWithRelatedEntitiesToDb(ResidentContactContext context, int? id = null,
             string firstname = null, string lastname = null, int? contactTypeLookupId = null, int? contactSubTypeLookupId = null)
         {
@@ -58,7 +60,7 @@ namespace ResidentContactApi.Tests
             };
         }
 
-        public static string AddCrmContactIdForResidentId(ResidentContactContext context, int residentId)
+        public static ExternalSystemId AddCrmContactIdForResidentId(ResidentContactContext context, int residentId)
         {
             var fixture = new Fixture();
             var externalSystemLookup = new ExternalSystemLookup
@@ -76,7 +78,21 @@ namespace ResidentContactApi.Tests
             };
             context.ExternalSystemIds.Add(externalLink);
             context.SaveChanges();
-            return externalLink.ExternalIdValue;
+            return externalLink;
+        }
+
+        public static Resident AddResidentRecordToTheDatabase(ResidentContactContext context)
+        {
+            var resident = new Resident
+            {
+                FirstName = _faker.Random.Word(),
+                LastName = _faker.Random.Word(),
+                DateOfBirth = _faker.Date.Past(),
+                Gender = _faker.Random.Char()
+            };
+            context.Residents.Add(resident);
+            context.SaveChanges();
+            return resident;
         }
     }
 }

--- a/ResidentContactApi.Tests/V1/E2ETests/CreateContactRecordTests.cs
+++ b/ResidentContactApi.Tests/V1/E2ETests/CreateContactRecordTests.cs
@@ -72,7 +72,7 @@ namespace ResidentContactApi.Tests.V1.E2ETests
             var resident = E2ETestsHelper.AddPersonWithRelatedEntitiesToDb(ResidentContactContext,
                 contactTypeLookupId: contactRequest.TypeId,
                 contactSubTypeLookupId: contactRequest.SubtypeId);
-            contactRequest.NccContactId = E2ETestsHelper.AddCrmContactIdForResidentId(ResidentContactContext, resident.Id);
+            contactRequest.NccContactId = E2ETestsHelper.AddCrmContactIdForResidentId(ResidentContactContext, resident.Id).ExternalIdValue;
 
             var response = await CallPostEndpointWithRequest(contactRequest).ConfigureAwait(true);
 

--- a/ResidentContactApi.Tests/V1/E2ETests/InsertResidentRecordTests.cs
+++ b/ResidentContactApi.Tests/V1/E2ETests/InsertResidentRecordTests.cs
@@ -100,7 +100,7 @@ namespace ResidentContactApi.Tests.V1.E2ETests
                 DateOfBirth = _faker.Date.Past(),
                 ExternalReferences = new List<InsertExternalReferenceRequest> {
                     new InsertExternalReferenceRequest {
-                        ExternalReferenceValue =crmReference.ExternalIdValue,
+                        ExternalReferenceValue = crmReference.ExternalIdValue,
                         ExternalReferenceName = "ContactId",
                         ExternalSystemId = crmReference.ExternalSystemLookupId
                     }

--- a/ResidentContactApi.Tests/V1/E2ETests/InsertResidentRecordTests.cs
+++ b/ResidentContactApi.Tests/V1/E2ETests/InsertResidentRecordTests.cs
@@ -1,0 +1,134 @@
+using Bogus;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ResidentContactApi.V1.Boundary.Requests;
+using ResidentContactApi.V1.Boundary.Response;
+using ResidentContactApi.V1.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.Tests.V1.E2ETests
+{
+    [TestFixture]
+    public class InsertResidentRecordTests : IntegrationTests<Startup>
+    {
+        private readonly Faker _faker = new Faker();
+
+        [Test]
+        public async Task ShouldReturn400IfRequestParametersAreMissing()
+        {
+            var request = new InsertResidentRequest
+            {
+                FirstName = _faker.Random.Word()
+            };
+
+            var url = new Uri("/api/v1/residents", UriKind.Relative);
+            using var requestContent =
+                new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(url, requestContent).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+        }
+        [Test]
+        public async Task ShouldReturn400IfNoExternalReferencesAreSupplied()
+        {
+            var request = new InsertResidentRequest
+            {
+                FirstName = _faker.Random.Word(),
+                LastName = _faker.Random.Word(),
+                DateOfBirth = _faker.Date.Past()
+            };
+
+            var url = new Uri("/api/v1/residents", UriKind.Relative);
+            using var requestContent =
+                new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(url, requestContent).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+        }
+
+        [Test]
+        public async Task ShouldReturn201WhenNewResidentRecordIsInserted()
+        {
+            var externalSystemLookup = new ExternalSystemLookup
+            {
+                Name = _faker.Random.Word()
+            };
+            ResidentContactContext.ExternalSystemLookups.Add(externalSystemLookup);
+            ResidentContactContext.SaveChanges();
+
+            var request = new InsertResidentRequest
+            {
+                FirstName = _faker.Random.Word(),
+                LastName = _faker.Random.Word(),
+                DateOfBirth = _faker.Date.Past(),
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _faker.Random.Word(),
+                        ExternalReferenceName = _faker.Random.Word(),
+                        ExternalSystemId = externalSystemLookup.Id
+                    }
+                 }
+            };
+
+            var url = new Uri("/api/v1/residents", UriKind.Relative);
+            using var requestContent =
+                new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(url, requestContent).ConfigureAwait(true);
+            var content = response.Content.ReadAsStringAsync().Result;
+            var insertResidentResponse = JsonConvert.DeserializeObject<InsertResidentResponse>(content);
+
+            response.StatusCode.Should().Be(201);
+            CheckResidentHasBeenInserted(insertResidentResponse.ResidentId, request);
+        }
+
+
+        [Test]
+        public async Task ShouldReturn200IfResidentIsAlreadyPresentInDatabase()
+        {
+
+            var residentInDb = E2ETestsHelper.AddResidentRecordToTheDatabase(ResidentContactContext);
+            var crmReference = E2ETestsHelper.AddCrmContactIdForResidentId(ResidentContactContext, residentInDb.Id);
+
+            var request = new InsertResidentRequest
+            {
+                FirstName = _faker.Random.Word(),
+                LastName = _faker.Random.Word(),
+                DateOfBirth = _faker.Date.Past(),
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue =crmReference.ExternalIdValue,
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = crmReference.ExternalSystemLookupId
+                    }
+                 }
+            };
+
+            var url = new Uri("/api/v1/residents", UriKind.Relative);
+            using var requestContent =
+                new StringContent(JsonConvert.SerializeObject(request), Encoding.UTF8, "application/json");
+            var response = await Client.PostAsync(url, requestContent).ConfigureAwait(true);
+            var content = response.Content.ReadAsStringAsync().Result;
+            var insertResidentResponse = JsonConvert.DeserializeObject<InsertResidentResponse>(content);
+
+            response.StatusCode.Should().Be(200);
+            insertResidentResponse.ResidentRecordAlreadyPresent.Should().BeTrue();
+        }
+
+        private void CheckResidentHasBeenInserted(int residentId, InsertResidentRequest request)
+        {
+            var resident = ResidentContactContext.Residents.Where(x => x.Id == residentId).FirstOrDefault();
+            resident.FirstName.Should().Be(request.FirstName);
+            resident.LastName.Should().Be(request.LastName);
+            resident.Gender.Should().Be(request.Gender);
+            resident.DateOfBirth.Should().Be(request.DateOfBirth);
+
+            var externalReferences = ResidentContactContext.ExternalSystemIds.Where(x => x.ResidentId == residentId).ToList();
+            externalReferences.Count.Should().Be(request.ExternalReferences.Count);
+        }
+
+    }
+}

--- a/ResidentContactApi.Tests/V1/Gateways/ResidentGatewayTests.cs
+++ b/ResidentContactApi.Tests/V1/Gateways/ResidentGatewayTests.cs
@@ -11,6 +11,7 @@ using AutoFixture;
 using FluentAssertions.Equivalency;
 using ResidentContactApi.V1.Enums;
 using ResidentContactApi.V1.Factories;
+using ResidentContactApi.V1.Boundary.Requests;
 
 namespace ResidentContactApi.Tests.V1.Gateways
 {
@@ -196,7 +197,7 @@ namespace ResidentContactApi.Tests.V1.Gateways
         public void WhenGivenAContactIdInsertContactDetailsShouldLinkToTheCorrectResident()
         {
             var person = AddPersonRecordToDatabase();
-            var contactId = AddCrmContactIdForResident(person);
+            var contactId = AddExternalReferencesForAResident(person.Id, "CRM", "ContactId");
             var contactType = AddContactTypeToDatabase();
 
             var request = _fixture.Build<ContactDetailsDomain>()
@@ -205,7 +206,7 @@ namespace ResidentContactApi.Tests.V1.Gateways
                 .Without(x => x.SubtypeId)
                 .Create();
 
-            var responseId = _classUnderTest.InsertResidentContactDetails(null, contactId, request);
+            var responseId = _classUnderTest.InsertResidentContactDetails(null, contactId.ExternalIdValue, request);
 
             var savedContact = ResidentContactContext.ContactDetails.FirstOrDefault(res => res.Id == responseId);
             savedContact.Should().NotBeNull();
@@ -250,7 +251,7 @@ namespace ResidentContactApi.Tests.V1.Gateways
         public void WhenGivenBothIdsIfResidentCanNotBeFoundWillLinkUsingContactId()
         {
             var person = AddPersonRecordToDatabase();
-            var contactId = AddCrmContactIdForResident(person);
+            var contactId = AddExternalReferencesForAResident(person.Id, "CRM", "ContactId");
             var contactType = AddContactTypeToDatabase();
 
             var request = _fixture.Build<ContactDetailsDomain>()
@@ -259,11 +260,206 @@ namespace ResidentContactApi.Tests.V1.Gateways
                 .Without(x => x.SubtypeId)
                 .Create();
 
-            var responseId = _classUnderTest.InsertResidentContactDetails(person.Id + 3, contactId, request);
+            var responseId = _classUnderTest.InsertResidentContactDetails(person.Id + 3, contactId.ExternalIdValue, request);
 
             var savedContact = ResidentContactContext.ContactDetails.FirstOrDefault(res => res.Id == responseId);
             savedContact.Should().NotBeNull();
             savedContact.ResidentId.Should().Be(person.Id);
+        }
+
+        [Test]
+        public void IfResidentAlreadyExistsTheCorrectIdShouldBeReturned()
+        {
+            var resident = AddPersonRecordToDatabase();
+            var crmExternalReference = AddExternalReferencesForAResident(resident.Id, "CRM", "ContactId");
+
+            var request = new InsertResidentRequest
+            {
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = crmExternalReference.ExternalIdValue,
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = crmExternalReference.ExternalSystemLookupId
+                    }}
+            };
+
+            var response = _classUnderTest.InsertNewResident(request);
+
+            response.Should().NotBeNull();
+            response.ResidentId.Should().Be(resident.Id);
+            response.ResidentRecordAlreadyPresent.Should().BeTrue();
+        }
+
+        [Test]
+        public void IfResidentAlreadyExistOnlyExternalReferencesNotPresentShouldBeInserted()
+        {
+            var resident = AddPersonRecordToDatabase();
+            var crmExternalReference = AddExternalReferencesForAResident(resident.Id, "CRM", "ContactId");
+            var uhExternalReferenceHouseRef = AddExternalReferencesForAResident(resident.Id, "UH", "house_ref");
+            //create a request with three references, two of which exist already
+            var request = new InsertResidentRequest
+            {
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = crmExternalReference.ExternalIdValue,
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = crmExternalReference.ExternalSystemLookupId
+                    },
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = uhExternalReferenceHouseRef.ExternalIdValue,
+                        ExternalReferenceName = uhExternalReferenceHouseRef.ExternalIdName,
+                        ExternalSystemId = uhExternalReferenceHouseRef.ExternalSystemLookupId
+                    },
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceName = "person_no",
+                        ExternalReferenceValue = "1",
+                        ExternalSystemId = uhExternalReferenceHouseRef.ExternalSystemLookupId
+                    }
+            }
+            };
+
+            _classUnderTest.InsertExternalReferences(request, resident.Id);
+
+            var result = ResidentContactContext.ExternalSystemIds.ToList();
+            resident.Should().NotBeNull();
+            result.Should().NotBeEmpty();
+            result.Count.Should().Be(3);
+        }
+
+        [Test]
+        public void IfResidentAlreadyExistAndxternalReferencesAreAllPresentNoneShouldBeInserted()
+        {
+            var resident = AddPersonRecordToDatabase();
+            var crmExternalReference = AddExternalReferencesForAResident(resident.Id, "CRM", "ContactId");
+            var uhExternalReferenceHouseRef = AddExternalReferencesForAResident(resident.Id, "UH", "house_ref");
+            //create a request with three references, two of which exist already
+            var request = new InsertResidentRequest
+            {
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = crmExternalReference.ExternalIdValue,
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = crmExternalReference.ExternalSystemLookupId
+                    },
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = uhExternalReferenceHouseRef.ExternalIdValue,
+                        ExternalReferenceName = uhExternalReferenceHouseRef.ExternalIdName,
+                        ExternalSystemId = uhExternalReferenceHouseRef.ExternalSystemLookupId
+                    }
+                  }
+            };
+            _classUnderTest.InsertNewResident(request);
+            _classUnderTest.InsertExternalReferences(request, resident.Id);
+
+            var residentsInDatabase = ResidentContactContext.Residents.ToList();
+            residentsInDatabase.Should().NotBeNull();
+            residentsInDatabase.Should().NotBeEmpty();
+            residentsInDatabase.Count.Should().Be(1);
+
+            var externalReferencesInDatabase = ResidentContactContext.ExternalSystemIds.ToList();
+            externalReferencesInDatabase.Should().NotBeNull();
+            externalReferencesInDatabase.Should().NotBeEmpty();
+            externalReferencesInDatabase.Count.Should().Be(2);
+        }
+
+        [Test]
+        public void IfAResidentDoesNotExistItIsInsertedIntoDatabase()
+        {
+            //add external system lookup
+            var externalSystemLookup = new ExternalSystemLookup
+            {
+                Name = "CRM"
+            };
+            ResidentContactContext.ExternalSystemLookups.Add(externalSystemLookup);
+            ResidentContactContext.SaveChanges();
+
+            var request = new InsertResidentRequest
+            {
+                FirstName = "John",
+                LastName = "Smith",
+                DateOfBirth = DateTime.Parse("01-01-1950"),
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _fixture.Create<string>(),
+                        ExternalReferenceName = "ContactGuid",
+                        ExternalSystemId = externalSystemLookup.Id
+                    }
+                 }
+            };
+
+            var result = _classUnderTest.InsertNewResident(request);
+
+            var residentInDatabase = ResidentContactContext.Residents.Where(x => x.Id == result.ResidentId).FirstOrDefault();
+
+            result.Should().NotBe(0);
+            residentInDatabase.Should().NotBeNull();
+            residentInDatabase.FirstName.Should().Be(request.FirstName);
+            residentInDatabase.LastName.Should().Be(request.LastName);
+            residentInDatabase.DateOfBirth.Should().Be(request.DateOfBirth);
+            residentInDatabase.Gender.Should().Be(request.Gender);
+        }
+        [Test]
+        public void IfReferencesDoNotExistAllAreInsertedIntoDatabase()
+        {
+            var resident = AddPersonRecordToDatabase();
+            //add external system lookup
+            var externalSystemLookup = new ExternalSystemLookup
+            {
+                Name = "CRM"
+            };
+            ResidentContactContext.ExternalSystemLookups.Add(externalSystemLookup);
+            ResidentContactContext.SaveChanges();
+
+            var request = new InsertResidentRequest
+            {
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _fixture.Create<string>(),
+                        ExternalReferenceName = "ContactGuid",
+                        ExternalSystemId = externalSystemLookup.Id
+                    },
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _fixture.Create<string>(),
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = externalSystemLookup.Id
+                    }
+                 }
+            };
+
+            _classUnderTest.InsertExternalReferences(request, resident.Id);
+
+            var externalReferencesInDatabase = ResidentContactContext.ExternalSystemIds.Where(x => x.ResidentId == resident.Id).ToList();
+
+            externalReferencesInDatabase.Should().NotBeEmpty();
+            externalReferencesInDatabase.Count.Should().Be(2);
+            externalReferencesInDatabase[0].ExternalIdName.Should().Be(request.ExternalReferences[0].ExternalReferenceName);
+            externalReferencesInDatabase[0].ExternalIdValue.Should().Be(request.ExternalReferences[0].ExternalReferenceValue);
+            externalReferencesInDatabase[0].ExternalSystemLookupId.Should().Be(request.ExternalReferences[0].ExternalSystemId);
+            externalReferencesInDatabase[1].ExternalIdName.Should().Be(request.ExternalReferences[1].ExternalReferenceName);
+            externalReferencesInDatabase[1].ExternalIdValue.Should().Be(request.ExternalReferences[1].ExternalReferenceValue);
+            externalReferencesInDatabase[1].ExternalSystemLookupId.Should().Be(request.ExternalReferences[1].ExternalSystemId);
+        }
+        [Test]
+        public void IfExternalSystemLookupDoesNotExistAnExceptionShouldBeThrown()
+        {
+            var resident = AddPersonRecordToDatabase();
+            var request = new InsertResidentRequest
+            {
+                ExternalReferences = new List<InsertExternalReferenceRequest> {
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _fixture.Create<string>(),
+                        ExternalReferenceName = "ContactGuid",
+                        ExternalSystemId = 4 //random numbers
+                    },
+                    new InsertExternalReferenceRequest {
+                        ExternalReferenceValue = _fixture.Create<string>(),
+                        ExternalReferenceName = "ContactId",
+                        ExternalSystemId = 13
+                    }
+                 }
+            };
+
+            Assert.Throws<ExternalReferenceNotInsertedException>(() => _classUnderTest.InsertExternalReferences(request, resident.Id));
         }
 
         private static Func<EquivalencyAssertionOptions<Contact>, EquivalencyAssertionOptions<Contact>> IgnoreForeignDatabaseObjects()
@@ -306,24 +502,25 @@ namespace ResidentContactApi.Tests.V1.Gateways
             return domainEntity;
         }
 
-        private string AddCrmContactIdForResident(Resident person)
+        private ExternalSystemId AddExternalReferencesForAResident(int residentId, string externalSystemLookupName, string externalReferenceName)
         {
             var externalSystemLookup = new ExternalSystemLookup
             {
-                Name = "CRM"
+                Name = externalSystemLookupName
             };
             ResidentContactContext.ExternalSystemLookups.Add(externalSystemLookup);
             ResidentContactContext.SaveChanges();
+
             var externalLink = new ExternalSystemId
             {
-                ResidentId = person.Id,
-                ExternalIdName = "ContactId",
+                ResidentId = residentId,
+                ExternalIdName = externalReferenceName,
                 ExternalSystemLookupId = externalSystemLookup.Id,
                 ExternalIdValue = _fixture.Create<string>()
             };
             ResidentContactContext.ExternalSystemIds.Add(externalLink);
             ResidentContactContext.SaveChanges();
-            return externalLink.ExternalIdValue;
+            return externalLink;
         }
     }
 }

--- a/ResidentContactApi.Tests/V1/UseCase/InsertResidentRecordUseCaseTests.cs
+++ b/ResidentContactApi.Tests/V1/UseCase/InsertResidentRecordUseCaseTests.cs
@@ -1,0 +1,46 @@
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using ResidentContactApi.V1.Boundary.Requests;
+using ResidentContactApi.V1.Gateways;
+using ResidentContactApi.V1.UseCase;
+using ResidentContactApi.V1.Boundary.Response;
+
+namespace ResidentContactApi.Tests.V1.UseCase
+{
+    public class InsertResidentRecordUseCaseTests
+    {
+        private Mock<IResidentGateway> _mockResidentGateway;
+        private InsertResidentRecordUseCase _classUnderTest;
+        [SetUp]
+        public void Setup()
+        {
+            _mockResidentGateway = new Mock<IResidentGateway>();
+            _classUnderTest = new InsertResidentRecordUseCase(_mockResidentGateway.Object);
+        }
+
+        [Test]
+        public void EnsureThatInsertResidentRecordUseCaseCallsGateway()
+        {
+            var request = new InsertResidentRequest();
+            _mockResidentGateway.Setup(x => x.InsertNewResident(request)).Returns(new InsertResidentResponse());
+            _classUnderTest.Execute(request);
+
+            _mockResidentGateway.Verify(x => x.InsertNewResident(request), Times.Once);
+            _mockResidentGateway.Verify(x => x.InsertExternalReferences(request, It.IsAny<int>()), Times.Once);
+        }
+
+
+        [Test]
+        public void EnsureThatUseCaseReturnsTheIdReturnedByGateway()
+        {
+            var request = new InsertResidentRequest();
+            var expectedId = 1;
+            _mockResidentGateway.Setup(x => x.InsertNewResident(request)).Returns(new InsertResidentResponse { ResidentId = expectedId, ResidentRecordAlreadyPresent = false });
+            var result = _classUnderTest.Execute(request);
+
+            result.ResidentId.Should().Be(expectedId);
+            result.ResidentRecordAlreadyPresent.Should().BeFalse();
+        }
+    }
+}

--- a/ResidentContactApi/Startup.cs
+++ b/ResidentContactApi/Startup.cs
@@ -126,8 +126,8 @@ namespace ResidentContactApi
         {
             services.AddScoped<IGetAllUseCase, GetAllUseCase>();
             services.AddScoped<IGetByIdUseCase, GetByIdUseCase>();
-
             services.AddScoped<ICreateContactDetailsUseCase, CreateContactDetailsUseCase>();
+            services.AddScoped<IInsertResidentRecordUseCase, InsertResidentRecordUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/ResidentContactApi/V1/Boundary/Requests/InsertExternalReferenceRequest.cs
+++ b/ResidentContactApi/V1/Boundary/Requests/InsertExternalReferenceRequest.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.Boundary.Requests
+{
+    public class InsertExternalReferenceRequest
+    {
+        //Integer values used to map to stored lookup values/enums
+        /// <example>
+        /// 1
+        /// </example>
+        [Required]
+        public int ExternalSystemId { get; set; }
+        /// <example>
+        /// house_ref
+        /// </example>
+        [Required]
+        public string ExternalReferenceName { get; set; }
+        /// <example>
+        /// 012345
+        /// </example>
+        [Required]
+        public string ExternalReferenceValue { get; set; }
+    }
+}

--- a/ResidentContactApi/V1/Boundary/Requests/InsertResidentRequest.cs
+++ b/ResidentContactApi/V1/Boundary/Requests/InsertResidentRequest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.Boundary.Requests
+{
+    public class InsertResidentRequest
+    {
+        /// <example>
+        /// John
+        /// </example>
+        [Required]
+        public string FirstName { get; set; }
+        /// <example>
+        /// Smith
+        /// </example>
+        [Required]
+        public string LastName { get; set; }
+        /// <example>
+        /// M
+        /// </example>
+        public char? Gender { get; set; }
+        /// <example>
+        /// 01-01-1970
+        /// </example>
+        [Required]
+        public DateTime DateOfBirth { get; set; }
+        [Required]
+        public List<InsertExternalReferenceRequest> ExternalReferences { get; set; }
+    }
+}

--- a/ResidentContactApi/V1/Boundary/Response/InsertResidentResponse.cs
+++ b/ResidentContactApi/V1/Boundary/Response/InsertResidentResponse.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.Boundary.Response
+{
+    public class InsertResidentResponse
+    {
+        public int ResidentId { get; set; }
+        public bool ResidentRecordAlreadyPresent { get; set; }
+    }
+}

--- a/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
+++ b/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
@@ -108,11 +108,11 @@ namespace ResidentContactApi.V1.Controllers
 
                 return CreatedAtAction("ViewResidentRecord", resident);
             }
-            catch (ResidentNotInsertedException ex)//TODO create exception
+            catch (ResidentNotInsertedException ex)
             {
                 return StatusCode(500, $"Resident could not be inserted - {ex.Message}");
             }
-            catch (ExternalReferenceNotInsertedException ex)//TODO create exception
+            catch (ExternalReferenceNotInsertedException ex)
             {
                 return StatusCode(500, $"External reference could not be inserted - {ex.Message}");
             }

--- a/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
+++ b/ResidentContactApi/V1/Controllers/ResidentContactApiController.cs
@@ -19,12 +19,14 @@ namespace ResidentContactApi.V1.Controllers
         private IGetAllUseCase _getAllUseCase;
         private IGetByIdUseCase _getByIdUseCase;
         private ICreateContactDetailsUseCase _createContactDetails;
+        private IInsertResidentRecordUseCase _insertResidentRecordUseCase;
         public ResidentContactApiController(IGetAllUseCase getAllUseCase, IGetByIdUseCase getByIdUseCase,
-            ICreateContactDetailsUseCase createContactDetails)
+            ICreateContactDetailsUseCase createContactDetails, IInsertResidentRecordUseCase insertResidentRecordUseCase)
         {
             _getAllUseCase = getAllUseCase;
             _getByIdUseCase = getByIdUseCase;
             _createContactDetails = createContactDetails;
+            _insertResidentRecordUseCase = insertResidentRecordUseCase;
         }
         /// <summary>
         /// ...
@@ -86,6 +88,33 @@ namespace ResidentContactApi.V1.Controllers
             catch (ResidentNotFoundException)
             {
                 return BadRequest("Resident ID and/or NCC Contact ID do not link to a resident record");
+            }
+        }
+
+        /// <summary>
+        /// Create a new resident record
+        /// </summary>
+        /// <response code="201">Successful operation</response>
+        /// <response code="400">Contact not found for specified ID</response>
+        [ProducesResponseType(typeof(ResidentResponse), StatusCodes.Status201Created)]
+        [HttpPost]
+        [Route("residents")]
+        public IActionResult InsertResident([FromBody] InsertResidentRequest request)
+        {
+            try
+            {
+                var resident = _insertResidentRecordUseCase.Execute(request);
+                if (resident.ResidentRecordAlreadyPresent) return Ok(resident);
+
+                return CreatedAtAction("ViewResidentRecord", resident);
+            }
+            catch (ResidentNotInsertedException ex)//TODO create exception
+            {
+                return StatusCode(500, $"Resident could not be inserted - {ex.Message}");
+            }
+            catch (ExternalReferenceNotInsertedException ex)//TODO create exception
+            {
+                return StatusCode(500, $"External reference could not be inserted - {ex.Message}");
             }
         }
     }

--- a/ResidentContactApi/V1/Domain/ExternalReferenceNotInsertedException.cs
+++ b/ResidentContactApi/V1/Domain/ExternalReferenceNotInsertedException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.Domain
+{
+    public class ExternalReferenceNotInsertedException : Exception
+    {
+        public ExternalReferenceNotInsertedException(string message) : base(message)
+        { }
+    }
+}

--- a/ResidentContactApi/V1/Domain/ResidentNotInsertedException.cs
+++ b/ResidentContactApi/V1/Domain/ResidentNotInsertedException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.Domain
+{
+    public class ResidentNotInsertedException : Exception
+    {
+        public ResidentNotInsertedException(string message) : base(message)
+        { }
+    }
+}

--- a/ResidentContactApi/V1/Gateways/IResidentGateway.cs
+++ b/ResidentContactApi/V1/Gateways/IResidentGateway.cs
@@ -1,6 +1,8 @@
 using ResidentDomain = ResidentContactApi.V1.Domain.ResidentDomain;
 using System.Collections.Generic;
 using ResidentContactApi.V1.Domain;
+using ResidentContactApi.V1.Boundary.Requests;
+using ResidentContactApi.V1.Boundary.Response;
 
 namespace ResidentContactApi.V1.Gateways
 {
@@ -9,5 +11,7 @@ namespace ResidentContactApi.V1.Gateways
         List<ResidentDomain> GetResidents(int limit, int cursor, string firstName, string lastName);
         ResidentDomain GetResidentById(int id);
         int? InsertResidentContactDetails(int? residentId, string nccContactId, ContactDetailsDomain contactDetails);
+        InsertResidentResponse InsertNewResident(InsertResidentRequest request);
+        void InsertExternalReferences(InsertResidentRequest request, int residentId);
     }
 }

--- a/ResidentContactApi/V1/UseCase/InsertResidentRecordUseCase.cs
+++ b/ResidentContactApi/V1/UseCase/InsertResidentRecordUseCase.cs
@@ -1,0 +1,27 @@
+using ResidentContactApi.V1.Boundary.Requests;
+using ResidentContactApi.V1.Boundary.Response;
+using ResidentContactApi.V1.Gateways;
+using ResidentContactApi.V1.UseCase.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.UseCase
+{
+    public class InsertResidentRecordUseCase : IInsertResidentRecordUseCase
+    {
+        private IResidentGateway _residentGateway;
+        public InsertResidentRecordUseCase(IResidentGateway gateway)
+        {
+            _residentGateway = gateway;
+        }
+        public InsertResidentResponse Execute(InsertResidentRequest request)
+        {
+            var resident = _residentGateway.InsertNewResident(request);
+            //even if resident already in db, attempt to insert possible new external references
+            _residentGateway.InsertExternalReferences(request, resident.ResidentId);
+            return resident;
+        }
+    }
+}

--- a/ResidentContactApi/V1/UseCase/Interfaces/IInsertResidentRecordUseCase.cs
+++ b/ResidentContactApi/V1/UseCase/Interfaces/IInsertResidentRecordUseCase.cs
@@ -1,0 +1,14 @@
+using ResidentContactApi.V1.Boundary.Requests;
+using ResidentContactApi.V1.Boundary.Response;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ResidentContactApi.V1.UseCase.Interfaces
+{
+    public interface IInsertResidentRecordUseCase
+    {
+        InsertResidentResponse Execute(InsertResidentRequest request);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/jira/software/projects/PA/boards/35?selectedIssue=PA-345

## Describe this PR

Add an endpoint to insert new resident records. It is expected that external references will be supplied at the point of creating a resident record, so those are also inserted in the database as part of this endpoint. 

Add a summary of the problem and any additional context that helps explain what the issue we're trying to solve is.

The endpoint also accommodates for checking if a contact with a given CRM GUID id already exists. This is because the main use case for this API (for now) is to replace the NCC contact details functionality and move it away from CRM 365. With CRM 365, we maintain the same person record even if their external references change (e.g. they moved to a new tenancy agreement) - so this endpoint accounts for scenarios when it's the same person (same CRM id), but new references are available. 

Add descriptions of what changes were made to address the problem and provide a solution.

- There is additional logic to check if a resident record already exists based on CRM ID. If it exists, we are also checking the external references and if all of them provided are already present - if not, we insert them. 

- If a resident does already exist, we return 200 status code as no resident record has been created

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Checked all code for possible refactoring - It has been agreed that there will be a separate ticket for refactoring code and separating the two gateways
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

