### PR TITLE
Removed stale CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty


### PR DESCRIPTION
# What:
 - Remove a stale CODEOWNERS file.

# Why:
 - No one owns this repository anymore.
 - This repository is temporarily unarchived for the purposes of infrastructure management.
 - All listed CODEOWNERS have either left the organisation, or their role as a developer.
 - There's no reason to gatekeep PRs from being merged with specific approval within this repo. If there are any objections, I'm happy to hear them out.