### PR TITLE
Trigger `development` workflow from the main workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,9 +280,17 @@ workflows:
           filters:
             branches:
               only: master
-      - build-and-test:
+      - start-staging-release:
+          type: approval
           requires:
             - deploy-to-development
+          filters:
+            branches:
+              only: master
+      # TODO:
+      - build-and-test:
+          requires:
+            - start-staging-release
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,10 +238,12 @@ jobs:
           stage: "production"
 
 workflows:
-  check-and-deploy-development:
+  check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting
-      - build-and-test
+      - build-and-test:
+          requires:
+            - check-code-formatting
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
@@ -249,9 +251,19 @@ workflows:
           filters:
             branches:
               only: development
-      - terraform-init-and-apply-to-development:
+      - preview-terraform-development:
           requires:
             - assume-role-development
+          filters:
+            branches:
+              only: master
+      - permit-development-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-development
+      - terraform-init-and-apply-to-development:
+          requires:
+            - permit-development-terraform-release
           filters:
             branches:
               only: development
@@ -268,9 +280,9 @@ workflows:
           filters:
             branches:
               only: development
-  check-and-deploy-staging-and-production:
-    jobs:
       - build-and-test:
+          requires:
+            - deploy-to-development
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: development
+              only: master
       - preview-terraform-development:
           requires:
             - assume-role-development
@@ -266,20 +266,20 @@ workflows:
             - permit-development-terraform-release
           filters:
             branches:
-              only: development
+              only: master
       - migrate-database-development:
           requires:
               - terraform-init-and-apply-to-development
               - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - build-and-test:
           requires:
             - deploy-to-development


### PR DESCRIPTION
# What:
 - Make the development workflow trigger from the `master` branch.

# Why:
 - The `development` branch is heavily out of sync with `master`. As such we want to be able to trigger development pipeline to retire the environment without needing to go through out of sync branch.

# Notes:
- The assume role step may still be broken. It will get fixed later on.