### PR TITLE
Fix `{environment}APIs` account vpc names references.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -30,8 +30,8 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "development_vpc" {
   tags = {
-    Name = "vpc-development-apis-development"
-    }
+    Name = "apis-dev"
+  }
 }
 
 data "aws_subnet_ids" "development_private_subnets" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -21,7 +21,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "production_vpc" {
   tags = {
-    Name = "vpc-production-apis-production"
+    Name = "apis-prod"
   }
 }
 data "aws_subnet_ids" "production" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -21,7 +21,7 @@ terraform {
 /*    POSTGRES SET UP    */
 data "aws_vpc" "staging_vpc" {
   tags = {
-    Name = "vpc-staging-apis-staging"
+    Name = "apis-stg"
   }
 }
 data "aws_subnet_ids" "staging" {


### PR DESCRIPTION
# What:
 - Fix out of sync VPC reference names for the xxxAPIs AWS accounts.

# Why:
 - The TF plan preview won't work without the target.