### PR TITLE
Upgrade pipeline's node version from v13 to v20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ commands:
       - run:
           name: Install Node.js
           command: |
-            curl -sL https://deb.nodesource.com/setup_13.x | bash -
+            curl -sL https://deb.nodesource.com/setup_20.x | bash -
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI


### PR DESCRIPTION
# What:
 - Upgrade the pipeline's node version from v13 to v20.

# Why:
- So the latest version of `serverless` we need works.
- Version 13 is deprecated.
 