### PR TITLE
Limit serverless to version 3 to stay under old license.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |


### PR DESCRIPTION
# What:
- Placed a version cap to keep `serverless` package used for API deployment at major version 3.

# Why:
- New version requires an account with a paid license.

# Notes:
- For more details see [this PR](https://github.com/LBHackney-IT/housing-finance-interim-api/pull/140).
