### PR TITLE
Escort serverless `development` resources to the cloud heaven.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,12 @@ commands:
           name: Deploy lambda
           command: |
             cd ./ResidentContactApi/
-            sls deploy --stage <<parameters.stage>> --conceal
+            if [ "<<parameters.stage>>" = "development" ]
+            then
+              sls remove --stage <<parameters.stage>> --verbose
+            else
+              sls deploy --stage <<parameters.stage>> --conceal
+            fi
   migrate-database:
     description: "Migrate database"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ commands:
             chmod +x ./build.sh
             ./build.sh
       - run:
-          name: Deploy lambda
+          name: Deploy or Destroy lambda
           command: |
             cd ./ResidentContactApi/
             if [ "<<parameters.stage>>" = "development" ]


### PR DESCRIPTION
# What:
- Adding in a conditional removal of AWS resources for `development` environment.

# Why:
- The environment is not used. The development database for the API has long been destroyed.

# Notes:
- Achieving this via `sls remove` command.