### PR TITLE
Remove `development` environment Terraform managed resrouces.

### DIFF
--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -11,12 +11,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-  application_name = "Resident Contact API"
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
 
 terraform {
   backend "s3" {
@@ -25,48 +19,4 @@ terraform {
     region  = "eu-west-2"
     key     = "services/resident-contact-api/state"
   }
-}
-
-/*    POSTGRES SET UP    */
-data "aws_vpc" "development_vpc" {
-  tags = {
-    Name = "apis-dev"
-  }
-}
-
-data "aws_subnet_ids" "development_private_subnets" {
-  vpc_id = data.aws_vpc.development_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
-    }
-}
-
- data "aws_ssm_parameter" "resident_contact_postgres_password" {
-   name = "/resident-contact-api/development/postgres-password"
- }
-
- data "aws_ssm_parameter" "resident_contact_postgres_username" {
-   name = "/resident-contact-api/development/postgres-username"
- }
-
-module "postgres_db_development" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "development"
-  vpc_id = data.aws_vpc.development_vpc.id
-  db_engine = "postgres"
-  db_engine_version = "11.1"
-  db_identifier = "resident-contact-development-db"
-  db_instance_class = "db.t2.micro"
-  db_name = "resident-contact-development"
-  db_port  = 5302
-  db_username = data.aws_ssm_parameter.resident_contact_postgres_username.value
-  db_password = data.aws_ssm_parameter.resident_contact_postgres_password.value
-  subnet_ids = data.aws_subnet_ids.development_private_subnets.ids
-  db_allocated_storage = 20
-  maintenance_window ="sun:10:00-sun:10:30"
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
 }


### PR DESCRIPTION
# What:
 - Remove `development` environment postgres database module resource configuration.

# Why:
 - The database has been deleted long time ago manually via AWS console.
 - Development environment hasn't been in use in many years.
