### PR TITLE
Delete serverless-managed `staging` resources.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
           name: Deploy or Destroy lambda
           command: |
             cd ./ResidentContactApi/
-            if [ "<<parameters.stage>>" = "environment" ]
+            if [ "<<parameters.stage>>" = "staging" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else


### PR DESCRIPTION
# What:
 - Remove `staging` environment's serverless-managed resources.

# Why:
 - The environment hasn't been in use for 3 years _(see screenshot)_.
 - The database is pending removal _(will be removed in successive PRs)_.

# Screenshots:

| Staging environment API logs |
| --- |
| ![image](https://github.com/user-attachments/assets/2b1f20de-51a9-4057-9735-a1e6014d0c21) |