### PR TITLE
Remove serverless related staging environment references.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,16 +298,10 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy-to-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
       - permit-production-terraform-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - migrate-database-staging
       - assume-role-production:
           context: api-assume-role-production-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
           name: Deploy or Destroy lambda
           command: |
             cd ./ResidentContactApi/
-            if [ "<<parameters.stage>>" = "staging" ]
+            if [ "<<parameters.stage>>" = "environment" ]
             then
               sls remove --stage <<parameters.stage>> --verbose
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,11 +196,6 @@ jobs:
     steps:
       - preview-terraform:
           environment: "production"
-  deploy-to-staging:
-    executor: docker-dotnet
-    steps:
-      - deploy-lambda:
-          stage: "staging"
   deploy-to-production:
     executor: docker-dotnet
     steps:


### PR DESCRIPTION
# What:
 - Remove all `staging` references of anything serverless related from the pipeline & its configuration.

# Why:
 - Serverless-managed `staging` resources have been removed _(see PR #49)_. 
