### PR TITLE
Remove `staging` terraform-managed resources (which includes database).

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -18,24 +18,3 @@ terraform {
   }
 }
 
-/*    POSTGRES SET UP    */
-data "aws_vpc" "staging_vpc" {
-  tags = {
-    Name = "apis-stg"
-  }
-}
-data "aws_subnet_ids" "staging" {
-  vpc_id = data.aws_vpc.staging_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"] 
-  }
-}
-
-data "aws_ssm_parameter" "resident_contact_postgres_db_password" {
-  name = "/resident-contact-api/staging/postgres-password"
-}
-
-data "aws_ssm_parameter" "resident_contact_postgres_username" {
-  name = "/resident-contact-api/staging/postgres-username"
-}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -2,12 +2,6 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-   application_name = "resident contact api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
 
 terraform {
   backend "s3" {

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -32,31 +32,10 @@ data "aws_subnet_ids" "staging" {
   }
 }
 
- data "aws_ssm_parameter" "resident_contact_postgres_db_password" {
-   name = "/resident-contact-api/staging/postgres-password"
- }
+data "aws_ssm_parameter" "resident_contact_postgres_db_password" {
+  name = "/resident-contact-api/staging/postgres-password"
+}
 
- data "aws_ssm_parameter" "resident_contact_postgres_username" {
-   name = "/resident-contact-api/staging/postgres-username"
- }
-
-module "postgres_db_staging" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "staging"
-  vpc_id = data.aws_vpc.staging_vpc.id
-  db_identifier = "resident-contact-db"
-  db_name = "resident_contact_db"
-  db_port  = 5302
-  subnet_ids = data.aws_subnet_ids.staging.ids
-  db_engine = "postgres"
-  db_engine_version = "11.1" //DMS does not work well with v12
-  db_instance_class = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window = "sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.resident_contact_postgres_username.value
-  db_password = data.aws_ssm_parameter.resident_contact_postgres_db_password.value
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
+data "aws_ssm_parameter" "resident_contact_postgres_username" {
+  name = "/resident-contact-api/staging/postgres-username"
 }


### PR DESCRIPTION
# What:
 - Remove `staging` environment's terraform resources configuration.

# Why:
 - We're looking to retire staging environment due to lack of its use (see more PR #49)
 - The terraform-managed staging database hasn't received any connections in 15 months _(checked with 1 hour binning, also confirmed no connections for 3 months with 5 minutes interval)_.

# Notes:
 - A manual snapshot of the database was taken under `StagingAPIs` AWS account, with the snapshot name of: `resident-contact-db-staging-not-used-in-3yrs-manual-snapshot`.

# Screenshots:

| No database connections in last 3 months | No connections right now |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/15b5f3bf-5d2f-427c-a400-81d21380a4d9) | ![image](https://github.com/user-attachments/assets/292483f4-6ae9-4a5b-8f3e-9e0f78ad6196) |