### PR TITLE
Fix production deploy permit-release requirements.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ workflows:
       - permit-production-release:
           type: approval
           requires:
-            - deploy-to-staging
+            - migrate-database-production
           filters:
             branches:
               only: master


### PR DESCRIPTION
# What:
 - Make production deployment permit step rely on migration having been done first.

# Why:
 - It doesn't make sense the requirement to be staging deployment, when the production changes may actually depend on database having been migrated.

# Notes:
 - This unblocks the pipeline for PR #51 .