### PR TITLE
Remove `production` terraform-managed resources (which includes database)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ workflows:
             branches:
               only: master
       - permit-database-migration:
+          type: approval
           requires:
             - terraform-init-and-apply-to-production
       - migrate-database-production:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,10 +247,12 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-production:
+      - permit-database-migration:
           requires:
             - terraform-init-and-apply-to-production
-            - assume-role-production
+      - migrate-database-production:
+          requires:
+            - permit-database-migration
           filters:
             branches:
               only: master

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -2,62 +2,13 @@ provider "aws" {
   region  = "eu-west-2"
   version = "~> 2.0"
 }
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
-locals {
-   application_name = "resident contact api"
-   parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
 
 terraform {
   backend "s3" {
-    bucket  = "terraform-state-production-apis" 
+    bucket  = "terraform-state-production-apis"
     encrypt = true
     region  = "eu-west-2"
-    key     = "services/resident-contact-api/state" 
+    key     = "services/resident-contact-api/state"
   }
 }
 
-/*    POSTGRES SET UP    */
-data "aws_vpc" "production_vpc" {
-  tags = {
-    Name = "apis-prod"
-  }
-}
-data "aws_subnet_ids" "production" {
-  vpc_id = data.aws_vpc.production_vpc.id
-  filter {
-    name   = "tag:Type"
-    values = ["private"] 
-  }
-}
-
- data "aws_ssm_parameter" "resident_contact_postgres_db_password" {
-   name = "/resident-contact-api/production/postgres-password"
- }
-
- data "aws_ssm_parameter" "resident_contact_postgres_username" {
-   name = "/resident-contact-api/production/postgres-username"
- }
-
-
-module "postgres_db_production" {
-  source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/postgres"
-  environment_name = "production"
-  vpc_id = data.aws_vpc.production_vpc.id
-  db_identifier = "resident-contact-db"
-  db_name = "resident_contact_db"
-  db_port  = 5300
-  subnet_ids = data.aws_subnet_ids.production.ids
-  db_engine = "postgres"
-  db_engine_version = "11.1" //DMS does not work well with v12
-  db_instance_class = "db.t2.micro"
-  db_allocated_storage = 20
-  maintenance_window = "sun:10:00-sun:10:30"
-  db_username = data.aws_ssm_parameter.resident_contact_postgres_username.value
-  db_password = data.aws_ssm_parameter.resident_contact_postgres_db_password.value
-  storage_encrypted = false
-  multi_az = false //only true if production deployment
-  publicly_accessible = false
-  project_name = "platform apis"
-}


### PR DESCRIPTION
# What
- Remove `production` environment's terraform resources configuration.

# Why
- It has been confirmed that this API is no longer in use and this is the final environment to decommission

# Notes:
- This API has a single constant connection which is an AWS canary calling the same endpoint.
- A manual snapshot of the database was taken under `ProductionAPI` AWS account, with the snapshot name of: `resident-contact-db-production-final-snapshot`.
